### PR TITLE
Add metrics middleware

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,3 +12,6 @@ BucketLogs = "$BUCKET_LOGS"
 LinkBase = "$LINK_BASE"
 Endpoint = "$AWS_S3_ENDPOINT"
 PathStyle = $PATH_STYLE
+
+[metrics]
+enabled = $DOGSTATSD_ENABLED

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/adevinta/vulcan-metrics-client v0.0.0-20200617105830-6078a0e12ebd
 	github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff
 	github.com/armon/go-metrics v0.0.0-20171117184120-7aa49fde8082 // indirect
 	github.com/aws/aws-sdk-go v1.12.70
@@ -23,7 +24,6 @@ require (
 	github.com/onsi/gomega v1.8.1 // indirect
 	github.com/pascaldekloe/goe v0.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/satori/go.uuid v1.2.1-0.20180103174451-36e9d2ebbde5
 	github.com/sirupsen/logrus v1.0.4
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataDog/datadog-go v3.7.1+incompatible h1:HmA9qHVrHIAqpSvoCYJ+c6qst0lgqEhNW6/KwfkHbS8=
+github.com/DataDog/datadog-go v3.7.1+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/adevinta/vulcan-metrics-client v0.0.0-20200617105830-6078a0e12ebd h1:gI+Ni3OjDLbA/ysKq+bdhwQHkTDCsDVWGM1I13gxaME=
+github.com/adevinta/vulcan-metrics-client v0.0.0-20200617105830-6078a0e12ebd/go.mod h1:M+oEghaodOSKYMScXw7Vpz9DypFo6PbgIEJrAexyWBo=
 github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff h1:ZazuZSOfV8oo70SWdjLQi+In4GSmJCA2rwsliyz9KNs=
 github.com/adevinta/vulcan-report v0.0.0-20190503133936-d8a2d4cb18ff/go.mod h1:GtAon6TymHFTOPwRdR7SHun/TSM1kyPMQYXxGLTR8eQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -11,6 +15,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 h1:MGKhKyiYrvMDZsmLR/+RGffQSXwEkXgfLSA08qDn9AI=
@@ -23,8 +28,6 @@ github.com/go-ini/ini v1.32.0 h1:/MArBHSS0TFR28yPPDK1vPIjt4wUnPBfb81i6iiyKvA=
 github.com/go-ini/ini v1.32.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/goadesign/goa v1.4.3 h1:aJz/3RD7sUXgwKxlszZBHuObxKTJbmgf/M1Z6/YPz8c=
 github.com/goadesign/goa v1.4.3/go.mod h1:d/9lpuZBK7HFi/7O0oXfwvdoIl+nx2bwKqctZe/lQao=
-github.com/goadesign/goa v2.0.8+incompatible h1:onGiQg1LrR4LaE0kw7vqaeOTPpPjej7bVelm67U+rro=
-github.com/goadesign/goa v2.0.8+incompatible/go.mod h1:d/9lpuZBK7HFi/7O0oXfwvdoIl+nx2bwKqctZe/lQao=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
@@ -49,7 +52,6 @@ github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/manelmontilla/goa v2.0.8+incompatible h1:87FA8Hw5l7CKsYaopvCxzzmpLugF9KVe+b1l1u4Kvl4=
 github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d h1:Zj+PHjnhRYWBK6RqCDBcAhLXoi3TzC27Zad/Vn+gnVQ=
 github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d/go.mod h1:WZy8Q5coAB1zhY9AOBJP0O6J4BuDfbupUDavKY+I3+s=
 github.com/manveru/gobdd v0.0.0-20131210092515-f1a17fdd710b h1:3E44bLeN8uKYdfQqVQycPnaVviZdBLbizFhU49mtbe4=
@@ -69,8 +71,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/satori/go.uuid v1.2.1-0.20180103174451-36e9d2ebbde5 h1:Jw7W4WMfQDxsXvfeFSaS2cHlY7bAF4MGrgnbd0+Uo78=
-github.com/satori/go.uuid v1.2.1-0.20180103174451-36e9d2ebbde5/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.0.4 h1:gzbtLsZC3Ic5PptoRG+kQj4L60qjK7H7XszrU163JNQ=
 github.com/sirupsen/logrus v1.0.4/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
@@ -85,8 +85,12 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
+github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea h1:CyhwejzVGvZ3Q2PSbQ4NRRYn+ZWv5eS1vlaEusT+bAI=
@@ -126,3 +130,5 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,7 @@
+package metrics
+
+// Config represents the metrics configuration.
+// parameters.
+type Config struct {
+	Enabled bool
+}

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	metrics "github.com/adevinta/vulcan-metrics-client"
-	vmetrics "github.com/adevinta/vulcan-metrics-client"
 	"github.com/goadesign/goa"
 )
 
@@ -55,7 +54,7 @@ var (
 )
 
 // NewMiddleware builds and returns a new metrics middleware for the API.
-func NewMiddleware(metricsClient vmetrics.Client) goa.Middleware {
+func NewMiddleware(metricsClient metrics.Client) goa.Middleware {
 	return func(h goa.Handler) goa.Handler {
 		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
 			// Do not push metrics for healtchcheck

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -1,0 +1,143 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	metrics "github.com/adevinta/vulcan-metrics-client"
+	vmetrics "github.com/adevinta/vulcan-metrics-client"
+	"github.com/goadesign/goa"
+)
+
+const (
+	// Endpoint path prefixes
+	getReportPathPrefix  = "/v1/reports"
+	postReportPathPrefix = "/v1/report"
+	getLogPathPrefix     = "/v1/logs"
+	postLogPathPrefix    = "/v1/raw"
+
+	// Endpoint actions
+	postReportAction = "PostReport"
+	getReportAction  = "GetReport"
+	postLogAction    = "PostLog"
+	getLogAction     = "GetLog"
+
+	unknownAction = "unknown"
+
+	// Metric names
+	metricTotal    = "vulcan.request.total"
+	metricDuration = "vulcan.request.duration"
+	metricFailed   = "vulcan.request.failed"
+
+	// Metric tags
+	resultsComponent = "results"
+
+	tagComponent = "component"
+	tagAction    = "action"
+	tagEntity    = "entity"
+	tagMethod    = "method"
+	tagStatus    = "status"
+
+	reportEntity = "report"
+	logEntity    = "log"
+)
+
+var (
+	actionToEntity = map[string]string{
+		postReportAction: reportEntity,
+		getReportAction:  reportEntity,
+		postLogAction:    logEntity,
+		getLogAction:     logEntity,
+	}
+)
+
+// NewMiddleware builds and returns a new metrics middleware for the API.
+func NewMiddleware(metricsClient vmetrics.Client) goa.Middleware {
+	return func(h goa.Handler) goa.Handler {
+		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
+			// Time and execute request
+			reqStart := time.Now()
+			err = h(ctx, rw, req)
+			reqEnd := time.Now()
+
+			// Collect metrics
+			resp := goa.ContextResponse(ctx)
+
+			httpMethod := req.Method
+			path := req.URL.Path
+			action := parseAction(httpMethod, path)
+			httpStatus := resp.Status
+			duration := reqEnd.Sub(reqStart).Milliseconds()
+			failed := httpStatus >= 400
+
+			// Build tags
+			tags := []string{
+				fmt.Sprint(tagComponent, ":", resultsComponent),
+				fmt.Sprint(tagAction, ":", action),
+				fmt.Sprint(tagEntity, ":", actionToEntity[action]),
+				fmt.Sprint(tagMethod, ":", httpMethod),
+				fmt.Sprint(tagStatus, ":", httpStatus),
+			}
+
+			// Push metrics
+			mm := buildMetrics(httpMethod, duration, failed, tags)
+
+			for _, met := range mm {
+				metricsClient.Push(met)
+			}
+
+			return err
+		}
+	}
+}
+
+func buildMetrics(httpMethod string, duration int64, failed bool, tags []string) []metrics.Metric {
+	mm := []metrics.Metric{
+		{
+			Name:  metricTotal,
+			Typ:   metrics.Count,
+			Value: 1,
+			Tags:  tags,
+		},
+		{
+			Name:  metricDuration,
+			Typ:   metrics.Histogram,
+			Value: float64(duration),
+			Tags:  tags,
+		},
+	}
+
+	if failed {
+		mm = append(mm, metrics.Metric{
+			Name:  metricFailed,
+			Typ:   metrics.Count,
+			Value: 1,
+			Tags:  tags,
+		})
+	}
+
+	return mm
+}
+
+func parseAction(httpMethod, path string) string {
+	if httpMethod == http.MethodGet {
+		if strings.HasPrefix(path, getReportPathPrefix) {
+			return getReportAction
+		}
+		if strings.HasPrefix(path, getLogPathPrefix) {
+			return getLogAction
+		}
+	} else if httpMethod == http.MethodPost {
+		if strings.HasPrefix(path, postReportPathPrefix) {
+			return postReportAction
+		}
+		if strings.HasPrefix(path, postLogPathPrefix) {
+			return postLogAction
+		}
+	}
+
+	return unknownAction
+}

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -58,6 +58,11 @@ var (
 func NewMiddleware(metricsClient vmetrics.Client) goa.Middleware {
 	return func(h goa.Handler) goa.Handler {
 		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
+			// Do not push metrics for healtchcheck
+			if req.URL.Path == "healthcheck" {
+				return h(ctx, rw, req)
+			}
+
 			// Time and execute request
 			reqStart := time.Now()
 			err = h(ctx, rw, req)

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -59,7 +59,7 @@ func NewMiddleware(metricsClient vmetrics.Client) goa.Middleware {
 	return func(h goa.Handler) goa.Handler {
 		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) (err error) {
 			// Do not push metrics for healtchcheck
-			if req.URL.Path == "healthcheck" {
+			if req.URL.Path == "/healthcheck" {
 				return h(ctx, rw, req)
 			}
 

--- a/metrics/middleware_test.go
+++ b/metrics/middleware_test.go
@@ -1,0 +1,330 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	metrics "github.com/adevinta/vulcan-metrics-client"
+	"github.com/goadesign/goa"
+)
+
+type mockMetricsClient struct {
+	metrics.Client
+	metrics         []metrics.Metric
+	expectedMetrics []metrics.Metric
+}
+
+func (c *mockMetricsClient) Push(metric metrics.Metric) {
+	c.metrics = append(c.metrics, metric)
+}
+
+// Verify verifies the matching between mock client
+// expected metrics and the actual pushed metrics.
+func (c *mockMetricsClient) Verify() error {
+	nMetrics := len(c.metrics)
+	nExpectedMetrics := len(c.expectedMetrics)
+
+	if nMetrics != nExpectedMetrics {
+		return fmt.Errorf(
+			"Number of metrics do not match: Expected %d, but got %d",
+			nExpectedMetrics, nMetrics)
+	}
+
+	for _, m := range c.metrics {
+		var found bool
+		for _, em := range c.expectedMetrics {
+			if cmpMetrics(m, em) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("Metrics do not match: Expected %v, but got %v",
+				c.expectedMetrics, c.metrics)
+		}
+	}
+
+	return nil
+}
+
+func cmpMetrics(got, exp metrics.Metric) bool {
+	if got.Name != exp.Name || got.Typ != exp.Typ ||
+		!reflect.DeepEqual(got.Tags, exp.Tags) {
+		return false
+	}
+	if got.Name == metricDuration {
+		// If metric is duration metric
+		// check got value >= exp value
+		return got.Value >= exp.Value
+	}
+	return got.Value == exp.Value
+
+}
+
+func TestMiddleware(t *testing.T) {
+	type input struct {
+		ctx context.Context
+		rw  http.ResponseWriter
+		req *http.Request
+		h   goa.Handler
+	}
+
+	testCases := []struct {
+		name            string
+		input           input
+		expectedMetrics []metrics.Metric
+	}{
+		{
+			name: "Should push metrics for GetReport action",
+			input: input{
+				// We have to create context through goa so we can
+				// obtain the HTTP response later on in middleware
+				// through goa context parsing.
+				ctx: goa.NewContext(nil, nil, nil, nil),
+				req: &http.Request{
+					Method: http.MethodGet,
+					URL: &url.URL{
+						Path: "/v1/reports/dt=2020-06-01/scan=06b38973-f395-4311-a4af-8f36e1b5b847/b4bda78e-12cc-4975-8362-95a5a10a3bfc.json",
+					},
+				},
+				h: func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+					// Modify goa ctx response to set
+					// http status.
+					resp := goa.ContextResponse(ctx)
+					resp.Status = http.StatusOK
+
+					time.Sleep(50 * time.Millisecond)
+
+					return nil
+				},
+			},
+			expectedMetrics: []metrics.Metric{
+				{
+					Name:  metricTotal,
+					Typ:   metrics.Count,
+					Value: 1,
+					Tags: []string{
+						fmt.Sprint(tagComponent, ":", resultsComponent),
+						fmt.Sprint(tagAction, ":", getReportAction),
+						fmt.Sprint(tagEntity, ":", reportEntity),
+						fmt.Sprint(tagMethod, ":", http.MethodGet),
+						fmt.Sprint(tagStatus, ":", http.StatusOK),
+					},
+				},
+				{
+					Name:  metricDuration,
+					Typ:   metrics.Histogram,
+					Value: 50,
+					Tags: []string{
+						fmt.Sprint(tagComponent, ":", resultsComponent),
+						fmt.Sprint(tagAction, ":", getReportAction),
+						fmt.Sprint(tagEntity, ":", reportEntity),
+						fmt.Sprint(tagMethod, ":", http.MethodGet),
+						fmt.Sprint(tagStatus, ":", http.StatusOK),
+					},
+				},
+			},
+		},
+		{
+			name: "Should push metrics for PostReport action",
+			input: input{
+				ctx: goa.NewContext(nil, nil, nil, nil),
+				req: &http.Request{
+					Method: http.MethodPost,
+					URL: &url.URL{
+						Path: "/v1/reportdt=2020-06-01/scan=06b38973-f395-4311-a4af-8f36e1b5b847/b4bda78e-12cc-4975-8362-95a5a10a3bfc",
+					},
+				},
+				h: func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+					resp := goa.ContextResponse(ctx)
+					resp.Status = http.StatusConflict
+
+					time.Sleep(20 * time.Millisecond)
+
+					return nil
+				},
+			},
+			expectedMetrics: []metrics.Metric{
+				{
+					Name:  metricTotal,
+					Typ:   metrics.Count,
+					Value: 1,
+					Tags: []string{
+						fmt.Sprint(tagComponent, ":", resultsComponent),
+						fmt.Sprint(tagAction, ":", postReportAction),
+						fmt.Sprint(tagEntity, ":", reportEntity),
+						fmt.Sprint(tagMethod, ":", http.MethodPost),
+						fmt.Sprint(tagStatus, ":", http.StatusConflict),
+					},
+				},
+				{
+					Name:  metricDuration,
+					Typ:   metrics.Histogram,
+					Value: 20,
+					Tags: []string{
+						fmt.Sprint(tagComponent, ":", resultsComponent),
+						fmt.Sprint(tagAction, ":", postReportAction),
+						fmt.Sprint(tagEntity, ":", reportEntity),
+						fmt.Sprint(tagMethod, ":", http.MethodPost),
+						fmt.Sprint(tagStatus, ":", http.StatusConflict),
+					},
+				},
+				{
+					Name:  metricFailed,
+					Typ:   metrics.Count,
+					Value: 1,
+					Tags: []string{
+						fmt.Sprint(tagComponent, ":", resultsComponent),
+						fmt.Sprint(tagAction, ":", postReportAction),
+						fmt.Sprint(tagEntity, ":", reportEntity),
+						fmt.Sprint(tagMethod, ":", http.MethodPost),
+						fmt.Sprint(tagStatus, ":", http.StatusConflict),
+					},
+				},
+			},
+		},
+		{
+			name: "Should push metrics for GetLog action",
+			input: input{
+				ctx: goa.NewContext(nil, nil, nil, nil),
+				req: &http.Request{
+					Method: http.MethodGet,
+					URL: &url.URL{
+						Path: "/v1/logs",
+					},
+				},
+				h: func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+					resp := goa.ContextResponse(ctx)
+					resp.Status = http.StatusOK
+
+					time.Sleep(35 * time.Millisecond)
+
+					return nil
+				},
+			},
+			expectedMetrics: []metrics.Metric{
+				{
+					Name:  metricTotal,
+					Typ:   metrics.Count,
+					Value: 1,
+					Tags: []string{
+						fmt.Sprint(tagComponent, ":", resultsComponent),
+						fmt.Sprint(tagAction, ":", getLogAction),
+						fmt.Sprint(tagEntity, ":", logEntity),
+						fmt.Sprint(tagMethod, ":", http.MethodGet),
+						fmt.Sprint(tagStatus, ":", http.StatusOK),
+					},
+				},
+				{
+					Name:  metricDuration,
+					Typ:   metrics.Histogram,
+					Value: 35,
+					Tags: []string{
+						fmt.Sprint(tagComponent, ":", resultsComponent),
+						fmt.Sprint(tagAction, ":", getLogAction),
+						fmt.Sprint(tagEntity, ":", logEntity),
+						fmt.Sprint(tagMethod, ":", http.MethodGet),
+						fmt.Sprint(tagStatus, ":", http.StatusOK),
+					},
+				},
+			},
+		},
+		{
+			name: "Should push metrics for PostLog action",
+			input: input{
+				ctx: goa.NewContext(nil, nil, nil, nil),
+				req: &http.Request{
+					Method: http.MethodPost,
+					URL: &url.URL{
+						Path: "/v1/raw",
+					},
+				},
+				h: func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+					resp := goa.ContextResponse(ctx)
+					resp.Status = http.StatusInternalServerError
+
+					time.Sleep(35 * time.Millisecond)
+
+					return nil
+				},
+			},
+			expectedMetrics: []metrics.Metric{
+				{
+					Name:  metricTotal,
+					Typ:   metrics.Count,
+					Value: 1,
+					Tags: []string{
+						fmt.Sprint(tagComponent, ":", resultsComponent),
+						fmt.Sprint(tagAction, ":", postLogAction),
+						fmt.Sprint(tagEntity, ":", logEntity),
+						fmt.Sprint(tagMethod, ":", http.MethodPost),
+						fmt.Sprint(tagStatus, ":", http.StatusInternalServerError),
+					},
+				},
+				{
+					Name:  metricDuration,
+					Typ:   metrics.Histogram,
+					Value: 35,
+					Tags: []string{
+						fmt.Sprint(tagComponent, ":", resultsComponent),
+						fmt.Sprint(tagAction, ":", postLogAction),
+						fmt.Sprint(tagEntity, ":", logEntity),
+						fmt.Sprint(tagMethod, ":", http.MethodPost),
+						fmt.Sprint(tagStatus, ":", http.StatusInternalServerError),
+					},
+				},
+				{
+					Name:  metricFailed,
+					Typ:   metrics.Count,
+					Value: 1,
+					Tags: []string{
+						fmt.Sprint(tagComponent, ":", resultsComponent),
+						fmt.Sprint(tagAction, ":", postLogAction),
+						fmt.Sprint(tagEntity, ":", logEntity),
+						fmt.Sprint(tagMethod, ":", http.MethodPost),
+						fmt.Sprint(tagStatus, ":", http.StatusInternalServerError),
+					},
+				},
+			},
+		},
+		{
+			name: "Should NOT push metrics for healthcheck endpoint",
+			input: input{
+				ctx: goa.NewContext(nil, nil, nil, nil),
+				req: &http.Request{
+					Method: http.MethodGet,
+					URL: &url.URL{
+						Path: "/healthcheck",
+					},
+				},
+				h: func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+					resp := goa.ContextResponse(ctx)
+					resp.Status = http.StatusOK
+					return nil
+				},
+			},
+			expectedMetrics: []metrics.Metric{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			metricsClient := &mockMetricsClient{
+				expectedMetrics: tc.expectedMetrics,
+			}
+
+			middleware := NewMiddleware(metricsClient)
+
+			middleware(tc.input.h)(tc.input.ctx, tc.input.rw, tc.input.req)
+
+			if err := metricsClient.Verify(); err != nil {
+				t.Fatalf("Error verifying pushed metrics: %v", err)
+			}
+		})
+	}
+}

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,7 @@
 export PORT=${PORT:-8080}
 export DEBUG=${DEBUG:-false}
 export PATH_STYLE=${PATH_STYLE:-false}
+export METRICS_ENABLED=${DOGSTATSD_ENABLED:-false}
 
 # Apply env variables
 cat config.toml | envsubst > run.toml

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 export PORT=${PORT:-8080}
 export DEBUG=${DEBUG:-false}
 export PATH_STYLE=${PATH_STYLE:-false}
-export METRICS_ENABLED=${DOGSTATSD_ENABLED:-false}
+export DOGSTATSD_ENABLED=${DOGSTATSD_ENABLED:-false}
 
 # Apply env variables
 cat config.toml | envsubst > run.toml


### PR DESCRIPTION
This PR adds a middleware to vulcan-results API to measure and push requests metrics, including metrics for:
- total requests
- total failed requests
- requests duration

And using tags for:
- requested action/endpoint
- entity associated with the endpoint (log/report)
- request status